### PR TITLE
update FXP to support ReaEQ format correctly (Reaper 7.16)

### DIFF
--- a/app/utils/FXP.ts
+++ b/app/utils/FXP.ts
@@ -276,7 +276,6 @@ export class FXP {
       if (writeXMLChunkData) {
         bf.binaryWriter?.writeString(xmlChunkData); // ChunkData, <ChunkSize>
       } else {
-        // Even though the main FXP is BigEndian format the preset chunk is saved in LittleEndian format
         bf.binaryWriter?.writeBytes(programSet.ChunkData);
       }
     } else if (content.FxMagic === "FxCk") {
@@ -396,7 +395,6 @@ export class FXP {
         bf.binaryReader?.readString(28).replace(/\0+$/, "") || "";
       programSet.ChunkSize = bf.binaryReader?.readInt32() || 0;
 
-      // Even though the main FXP is BigEndian format the preset chunk is saved in LittleEndian format
       programSet.ChunkData =
         bf.binaryReader?.readBytes(programSet.ChunkSize) ||
         new Uint8Array(0);

--- a/app/utils/FXP.ts
+++ b/app/utils/FXP.ts
@@ -277,7 +277,7 @@ export class FXP {
         bf.binaryWriter?.writeString(xmlChunkData); // ChunkData, <ChunkSize>
       } else {
         // Even though the main FXP is BigEndian format the preset chunk is saved in LittleEndian format
-        bf.binaryWriter?.writeBytes(programSet.ChunkData.reverse());
+        bf.binaryWriter?.writeBytes(programSet.ChunkData);
       }
     } else if (content.FxMagic === "FxCk") {
       // For Preset (Program) (.fxp) without chunk (magic = 'FxCk')
@@ -398,7 +398,7 @@ export class FXP {
 
       // Even though the main FXP is BigEndian format the preset chunk is saved in LittleEndian format
       programSet.ChunkData =
-        bf.binaryReader?.readBytes(programSet.ChunkSize).reverse() ||
+        bf.binaryReader?.readBytes(programSet.ChunkSize) ||
         new Uint8Array(0);
 
       // Read the XML chunk into memory


### PR DESCRIPTION
I was having an issue loading FXP files generated by the program in ReaEQ- it wouldn't work. They would be successfully verified by the verifier, but not in ReaEQ. However I noticed that valid FXP files exported by ReaEQ failed to be verified by the verifier- so there was a mismatch in the understood FXP format for this program and what was actually expected in ReaEQ.

I fixed these issues by removed the 'reverse()' on the programSet ChunkData in both the Read & Write methods.

Not really sure why there was this mismatch- if this is something that changed recently or not (seems like it'd be strange, because it would break old preset files right?). But nevertheless, it fixed the issue in my case so there is some sort of truth to it.

I have been using ReaEQ in Reaper v7.16